### PR TITLE
Remove temp 3rd party call to get IP + var decl

### DIFF
--- a/src/js/sessions.js
+++ b/src/js/sessions.js
@@ -86,18 +86,18 @@ function cookieSessionFromUtmParameter(){
 }
 
 // fetch the IP and store it in variable session
-function getandStoreIp(){
-    if(sessionStorage.getItem('ipVisitor') === null || sessionStorage.getItem('ipVisitor') == ""){
-        $.getJSON( "https://api.ipify.org?format=jsonp&callback=?", function(json) {
-            if(json.ip.length > 0){
-                sessionStorage.setItem('ipVisitor', json.ip);
-            }
-            else{
-                sessionStorage.setItem('ipVisitor', '');
-            }
-        })
-    }
-}
+// function getandStoreIp(){
+//     if(sessionStorage.getItem('ipVisitor') === null || sessionStorage.getItem('ipVisitor') == ""){
+//         $.getJSON( "https://api.ipify.org?format=jsonp&callback=?", function(json) {
+//             if(json.ip.length > 0){
+//                 sessionStorage.setItem('ipVisitor', json.ip);
+//             }
+//             else{
+//                 sessionStorage.setItem('ipVisitor', '');
+//             }
+//         })
+//     }
+// }
 
 cookieSessionFromUtmParameter();
-getandStoreIp();
+//getandStoreIp();

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,12 @@
-var path = window.location.pathname;
-var url = window.location.href;
-var isDebug = url.includes('debug=gorgias');
-var scriptBase = isDebug ? "http://127.0.0.1:5500" : "https://cdn.jsdelivr.net/gh/gorgias/gorgias-webflow@latest";
-
-
 // scripts belows requires Jquery or are not crucial for website work
 var Webflow = Webflow || [];
 Webflow.push(function () {
+    var path = window.location.pathname;
+    var url = window.location.href;
+    var isDebug = url.includes('debug=gorgias');
+    var scriptBase = isDebug ? "http://127.0.0.1:5500" : "https://cdn.jsdelivr.net/gh/gorgias/gorgias-webflow@latest";
 
-    newScript(scriptBase + '/src/js/autocompletefields.js','body',1); // once hubspot forms are loaded and display
+    newScript(scriptBase + '/src/js/autocompletefields.js','body',1);
     newScript(scriptBase + '/src/js/demo.js','body',1);
     newScript( 'https://js.na.chilipiper.com/marketing.js','body',1);
     newScript(scriptBase + '/src/js/schema.js','body',1);


### PR DESCRIPTION
In order to fix [this issue](https://linear.app/gorgias/issue/OPGTM-233/demo-booking-issue-calendar-not-loading), I

-  [removed temporarily the call to 3rd party API to get the IP and store it in a variable session. This call is currently written in jQuery but depending on how fast the jquery is loaded (depending of the visitor connection), it may create a error.](https://share.getcloudapp.com/YEueyl82)

- [Also, I've moved some variables into  a function to avoid global variables being erased and creating an issue](https://share.getcloudapp.com/YEueyl82)