### PR TITLE
Update for CP router fix

### DIFF
--- a/src/js/demo.js
+++ b/src/js/demo.js
@@ -123,6 +123,29 @@
                 console.log('customer_renewal passed');
             }
 
+            function forceChiliHeight(target){
+                try {
+                    var $el = $(target);
+                    if ($el && $el.length) {
+                        $el.css({'display':'block', 'overflow':'hidden'});
+                        // ensure inline override over CP injected styles
+                        $el.get(0).style.setProperty('height', '700px', 'important');
+                        $el.get(0).style.setProperty('max-height', '700px', 'important');
+                        console.log('forceChiliHeight applied' + $el.get(0).style.height);
+                    }
+                } catch(e){}
+            }
+
+            function safeTrack(name){
+                try{
+                    if (window.analytics && typeof window.analytics.track === 'function') {
+                        window.analytics.track(name);
+                    } else {
+                        console.warn('analytics.track unavailable:', name);
+                    }
+                }catch(e){}
+            }
+
             if(formName == 'demo'){
                 $('.privacy-policy').css('display','none');
             }
@@ -132,11 +155,13 @@
                 formId:'hsForm_' + eventId,
                 domElement: chilipiperDomWrapper,
                 onRouting: function () {
-                    analytics.track("cp_"+ formName +"_request_routing");
+                    forceChiliHeight(chilipiperDomWrapper);
+                    safeTrack("cp_"+ formName +"_request_routing");
                 },
 
                 onRouted: function () {
-                    analytics.track("cp_"+ formName +"_request_routed");
+                    forceChiliHeight(chilipiperDomWrapper);
+                    safeTrack("cp_"+ formName +"_request_routed");
                     // customize Frontend element based on the CP routing success
                     
                     if(eventId == demoLeadBfcmLp2025GiftFormId) {
@@ -147,11 +172,11 @@
                     }
                 },
                 onSuccess: function (data) { 
-                    analytics.track("cp_" + formName + "_booked");
+                    safeTrack("cp_" + formName + "_booked");
                     if(formName == 'demo'){
                         console.log('in success > demo')
                         $('.wrapper-post-demo-booked').removeClass('is-hidden');
-                        $(chilipiperDomWrapper).height('350px');
+                        forceChiliHeight(chilipiperDomWrapper);
                         $('.demo_step-wrapper').css('display','none');
                         $('.demo-new_status-bar').css('display','none');
                         $('.demo-form-hubspot-post-booking').css('margin-top','-3rem');                       
@@ -159,7 +184,7 @@
                 }, 
                 onError: function () {
                     // track ChiliPiper error through segment
-                    analytics.track("cp_" + formName + "_request_failed");
+                    safeTrack("cp_" + formName + "_request_failed");
 
                     // customize de frontend if CP request failed
                     if(eventId == demoLeadBfcmLp2025GiftFormId) {

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,8 @@ Webflow.push(function () {
 
     newScript(scriptBase + '/src/js/autocompletefields'+minBase+'.js','body',1);
     newScript(scriptBase + '/src/js/cta-url-parameters'+minBase+'.js','body',1);
-    newScript( 'https://js.na.chilipiper.com/marketing.js','body',1);
+    // newScript( 'https://js.na.chilipiper.com/marketing.js','body',1);
+    newScript( 'https://gorgias.chilipiper.com/concierge-js/cjs/concierge.js','body',1);
     newScript(scriptBase + '/src/js/schema'+minBase+'.js','body',1);
     // newScript(scriptBase + '/src/js/experiments'+minBase+'.js','body',1);
     newScript(scriptBase + '/src/js/get-started'+minBase+'.js','body',1);


### PR DESCRIPTION
• Height forcing helper added
Introduced a forceChiliHeight() function that applies inline styles (height: 700px, max-height: 700px, display: block, overflow: hidden) to the ChiliPiper wrapper, overriding injected styles.
• Safe analytics tracking
Added a safeTrack() wrapper around analytics.track to prevent runtime errors when analytics is not defined. This ensures tracking calls don’t break the flow.
• Callbacks updated
• onRouting, onRouted, onSuccess, and onError now use safeTrack() instead of directly calling analytics.track.
• forceChiliHeight() is called at the start of onRouting, onRouted, and inside onSuccess to guarantee the calendar gets a 700px height.
• Logging improvements
A console.log was added inside forceChiliHeight() to confirm when the height adjustment is applied.